### PR TITLE
添加Content-Type头部，这样Restlet才能正常显示图片，方便开发调试

### DIFF
--- a/imooc-security-core/src/main/java/com/imooc/security/core/validate/code/image/ImageCodeProcessor.java
+++ b/imooc-security-core/src/main/java/com/imooc/security/core/validate/code/image/ImageCodeProcessor.java
@@ -24,6 +24,7 @@ public class ImageCodeProcessor extends AbstractValidateCodeProcessor<ImageCode>
 	 */
 	@Override
 	protected void send(ServletWebRequest request, ImageCode imageCode) throws Exception {
+		request.getResponse().setContentType("image/jpeg");
 		ImageIO.write(imageCode.getImage(), "JPEG", request.getResponse().getOutputStream());
 	}
 


### PR DESCRIPTION
如果没有`Content-Type: image/jpeg`头部，Restlet无法预览`/code/image`返回的验证码图片，加上这个头部后，就能正常预览图片了，方便开发调试